### PR TITLE
Only skip lines if the song has groups.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -512,7 +512,9 @@ function generate_prop6_file_contents($song)
                 'hotkey' => get_propresenter_section_hotkey($current_group_name),
                 'slides' => array()
             );
-            continue;
+            if ($has_groups === true) {
+                continue;
+            }
         }
 
         // Create a slide for every chunk of lines


### PR DESCRIPTION
When reading songs into the ProPresenter format,
only skip reading the line if the song has defined groups (Verse, Chrous, etc.)

If songs didn't have groups, the converter would cut out some lines.

This exposes converted songs to be subject to unwated text in the
beginning of the first verse. In my experience, this has been
font style text, for example "Times New Roman; Times New Roman CE; Times New Roman Cyr;".
But excessive text is better than lost text.